### PR TITLE
treesitter could not be ready; force parse before work with nodes

### DIFF
--- a/lua/md-table-tidy/parser.lua
+++ b/lua/md-table-tidy/parser.lua
@@ -85,6 +85,9 @@ end
 ---@return TSNode|nil
 function Parser.closest(targetType)
   local tree = vim.treesitter.get_parser()
+  if tree then
+    tree:parse()
+  end
   local node = TsUtils.get_node_at_cursor()
   while node do
     if node:type() == targetType then


### PR DESCRIPTION
I installed treesitter and md-table-tidy but <lead>tt showed error "Table under cursor not found".
The plugin started working as soon as I do `:InspectTree`.  

To have the AST ready I force parse a file before work with nodes.
Better solutions are welcome.

Thank you