### PR TITLE
fix: double width emojis ruining alignment

### DIFF
--- a/lua/md-table-tidy/render.lua
+++ b/lua/md-table-tidy/render.lua
@@ -84,7 +84,7 @@ end
 ---@param char? string filler
 ---@return string
 function Render:align_cell(str, width, align, char)
-  local strlen = vim.fn.strchars(str)
+  local strlen = vim.fn.strwidth(str)
   align = align or Table.alignments.LEFT
   char = char or " "
 

--- a/lua/md-table-tidy/table.lua
+++ b/lua/md-table-tidy/table.lua
@@ -34,7 +34,7 @@ function Table:add_column(header, align, width)
   table.insert(self.columns, {
     header = header,
     align = align or Table.alignments.DEFAULT,
-    width = width or vim.fn.strchars(header),
+    width = width or vim.fn.strwidth(header),
   })
 end
 
@@ -44,7 +44,7 @@ function Table:add_row(row)
     error("The number of cells does not match the number of columns.", 0)
   end
   for i, cell in ipairs(row) do
-    self.columns[i].width = math.max(self.columns[i].width, vim.fn.strchars(cell))
+    self.columns[i].width = math.max(self.columns[i].width, vim.fn.strwidth(cell))
   end
   table.insert(self.rows, row)
 end


### PR DESCRIPTION
Personally this fixes alignment issues in my terminal when there are double width emojis in the cells. Thanks for the plugin!